### PR TITLE
Stability fee adjustment

### DIFF
--- a/abis/Instrument.json
+++ b/abis/Instrument.json
@@ -909,5 +909,70 @@
     ],
     "name": "UpdateSocialLossInsuranceFund",
     "type": "event"
-  }
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+        {
+            "indexed": true,
+            "internalType": "uint32",
+            "name": "expiry",
+            "type": "uint32"
+        },
+        {
+            "indexed": true,
+            "internalType": "address",
+            "name": "trader",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint48",
+            "name": "rid",
+            "type": "uint48"
+        },
+        {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+        },
+        {
+            "indexed": false,
+            "internalType": "address",
+            "name": "operator",
+            "type": "address"
+        },
+        {
+            "indexed": false,
+            "internalType": "struct Range",
+            "name": "range",
+            "type": "tuple",
+            "components": [
+                {
+                    "internalType": "uint128",
+                    "name": "liquidity",
+                    "type": "uint128"
+                },
+                {
+                    "internalType": "uint128",
+                    "name": "entryFeeIndex",
+                    "type": "uint128"
+                },
+                {
+                    "internalType": "uint96",
+                    "name": "balance",
+                    "type": "uint96"
+                },
+                {
+                    "internalType": "uint160",
+                    "name": "sqrtEntryPX96",
+                    "type": "uint160"
+                }
+            ]
+        }
+    ],
+    "name": "WithdrawRangeFee",
+    "type": "event"
+  }  
 ]

--- a/config/base.json
+++ b/config/base.json
@@ -10,5 +10,6 @@
   "emg": "0x0b54c57fe93B9d71c29Bd5d466bAa2117bbF4D1D",
   "emgStartBlock": 16297301,
   "pyth": "0xE73d8117fdBD05aD7d632A3798c6925BFCdCF8AA",
-  "pythStartBlock": 16297301
+  "pythStartBlock": 16297301,
+  "stabilityFeeChangeBlock": 18245333
 }

--- a/config/blast.json
+++ b/config/blast.json
@@ -10,5 +10,6 @@
   "emg": "0x3BC7AD40aADc425CD670F8DcAE013E7c5eee3B76",
   "emgStartBlock": 193838,
   "pyth": "0x4A5EF7Ba050D7988A4A78020EEAD7202E05ADc08",
-  "pythStartBlock": 193838
+  "pythStartBlock": 193838,
+  "stabilityFeeChangeBlock": 7234469
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -11,7 +11,9 @@ import { Config } from '../../generated/schema';
 
 import {
     DEXV2,
+    MASK_24,
     MAX_INT_128,
+    MAX_INT_24,
     ONE,
     PERP_EXPIRY,
     SECONDS_PER_4HOUR,
@@ -296,6 +298,13 @@ export function asInt128(x: BigInt): BigInt {
     return x;
 }
 
+export function asInt24(x: BigInt): BigInt {
+    if (x.gt(MAX_INT_24)) {
+        x = x.minus(ONE.leftShift(24));
+    }
+    return x;
+}
+
 export function decodeReferralCode(input: Bytes): string {
     // only parse Insturment.sol `add(bytes32[2])` 7dc485ea  `place(bytes32[2])` e9544d84 `trade(bytes32[2])` 50347fcb tx
     let sig = input.toHexString().slice(2, 10).toLowerCase();
@@ -318,4 +327,13 @@ export function decodeReferralCode(input: Bytes): string {
     return decoded;
 }
 
-// console.info(formatDate());
+export class TickRange {
+    constructor(public tickLower: BigInt, public tickUpper: BigInt) {}
+}
+
+// find RangeTicks depending on key
+export function parseTicks(key: BigInt): TickRange {
+    const tickLower = asInt24(key.rightShift(24));
+    const tickUpper = asInt24(key.bitAnd(MASK_24));
+    return new TickRange(tickLower, tickUpper);
+}

--- a/template/const.mustache
+++ b/template/const.mustache
@@ -12,6 +12,8 @@ export let ZERO_ADDRESS = Address.fromString(ZERO_ADDRESS_STR);
 export const DEXV2 = 'DEXV2';
 
 export let MASK_128 = BigInt.fromI32(2).pow(128).minus(BigInt.fromI32(1));
+export let MASK_24 = BigInt.fromI32(2).pow(24).minus(BigInt.fromI32(1));
+
 export let ZERO = BigInt.fromI32(0);
 export let ONE = BigInt.fromI32(1);
 export let TWO = BigInt.fromI32(2);
@@ -19,6 +21,7 @@ export let WAD = BigInt.fromI32(10).pow(18);
 export let NEG_ONE = BigInt.fromI32(-1);
 
 export let MAX_INT_128 = ONE.leftShift(127).minus(ONE);
+export let MAX_INT_24 = ONE.leftShift(23).minus(ONE);
 
 export let PERP_EXPIRY = BigInt.fromI32(2).pow(32).minus(BigInt.fromI32(1));
 
@@ -52,3 +55,5 @@ export let DEFAULT_MAINTENANCE_MARGIN_RATIO = 500;
 export let DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
 // keccak256("OPERATOR");
 export let OPERATOR_ROLE = '0x523a704056dcd17bcf83bed8b68c59416dac1119be77755efe3bde0a64e46e0c';
+
+export let STABILITY_FEE_CHANGE_BLOCK = BigInt.fromI32({{stabilityFeeChangeBlock}});

--- a/template/subgraph.yaml
+++ b/template/subgraph.yaml
@@ -204,6 +204,8 @@ templates:
           handler: handleUpdatePosition
         - event: UpdateSocialLossInsuranceFund(indexed uint32,uint128,uint128,uint128)
           handler: handleUpdateSocialLossInsuranceFund
+        - event: WithdrawRangeFee(indexed uint32,indexed address,uint48,uint256,address,(uint128,uint128,uint96,uint160))
+          handler: handleWithdrawRangeFee          
   - kind: ethereum
     name: DexV2MarketContract
     network: {{network}}


### PR DESCRIPTION
1、handleWithdrawRangeFee to fix Range data
2、as stability fee goes to insurance fund after {{STABILITY_FEE_CHANGE_BLOCK}}, thus pool fee and liquidity fee should be calculated by fixed trading fee ratio which excludes stability fee.